### PR TITLE
Add link to Korean translation of Basic Tutorial 3

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,3 +11,4 @@ title: GStreamer101::Home
 
 - `Basic Tutorial 1: Hello World!` | [(C)](gst-docs-ko/basic-tutorial-1) | [(Python)](gst-docs-ko/basic-tutorial-1-python)
 - `Basic Tutorial 2: GStreamer concepts` | [(C)](gst-docs-ko/basic-tutorial-2) | [(Python)](#)
+- `Basic Tutorial 3: Dynamic Pipeline` | [(C)](gst-docs-ko/basic-tutorial-3) | [(Python)](#)


### PR DESCRIPTION
## 변경 내용
- `index.md`에 튜토리얼 3 (한글 번역)의 링크를 추가했습니다.

## 목적
- 사용자들이 튜토리얼 3의 번역 문서를 쉽게 접근할 수 있도록 하기 위함입니다.