### PR TITLE
Redirect root path (/) of gstreamer101.github.io to Slash Page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,12 +1,13 @@
 <header class="site-header">
     <div class="header-inner">
         <div class="site-brand">
-            <a href="{{ site.baseurl }}/">
+            <a href="https://slashpage.com/gstreamer101/">
                 <img src="{{ site.baseurl }}/assets/logo.png" alt="Logo" class="logo-img">
                 <span class="site-title-text">GStreamer 101</span>
             </a>
         </div>
         <nav class="site-nav">
+            <a href="{{ site.baseurl }}/projects/">Projects</a>
             <a href="https://github.com/gstreamer101" target="_blank" rel="noopener">
                 <img src="{{ site.baseurl }}/assets/github-icon.png" alt="GitHub" style="height: 16px; vertical-align: middle; margin-right: 4px;">
                 GitHub

--- a/index.md
+++ b/index.md
@@ -1,14 +1,6 @@
 ---
-layout: default
-title: GStreamer101::Home
+layout: none
+permalink: /
 ---
 
-# 환영합니다!
-이곳은 GStreamer101의 Pages입니다.
-
-## gst-docs-ko
-> This document is a Korean translation of the GStreamer basic tutorials. The original documentation can be found in the [GStreamer Official Documentation](https://gstreamer.freedesktop.org/documentation/tutorials/index.html).
-
-- `Basic Tutorial 1: Hello World!` | [(C)](gst-docs-ko/basic-tutorial-1) | [(Python)](gst-docs-ko/basic-tutorial-1-python)
-- `Basic Tutorial 2: GStreamer concepts` | [(C)](gst-docs-ko/basic-tutorial-2) | [(Python)](#)
-- `Basic Tutorial 3: Dynamic Pipeline` | [(C)](gst-docs-ko/basic-tutorial-3) | [(Python)](#)
+<meta http-equiv="refresh" content="0; url=https://slashpage.com/gstreamer101" />

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Projects
+permalink: /projects/
+---
+
+# 🔨 Ongoing Projects
+> This page introduces the projects currently maintained by the GStreamer 101 Korea community.
+
+## gst-docs-ko
+> This document is a Korean translation of the GStreamer basic tutorials. The original documentation can be found in the [GStreamer Official Documentation](https://gstreamer.freedesktop.org/documentation/tutorials/index.html).
+
+- `Basic Tutorial 1: Hello World!` | [(C)](gst-docs-ko/basic-tutorial-1) | [(Python)](gst-docs-ko/basic-tutorial-1-python)
+- `Basic Tutorial 2: GStreamer concepts` | [(C)](gst-docs-ko/basic-tutorial-2) | [(Python)](#)
+- `Basic Tutorial 3: Dynamic Pipeline` | [(C)](gst-docs-ko/basic-tutorial-3) | [(Python)](#)


### PR DESCRIPTION
## 변경 내용
- 깃허브 페이지 진입 시 슬래시 페이지 자동 이동되게 수정했습니다.
- 기존 index.md 사용하지 못함으로 튜토리얼 한글 번역 링크는 별도의 프로젝트 페이지를 생성해 해당 페이지는 진입 가능하도록 수정했습니다. (@dlgus8648 한글 번역 링크는 projects.md 에 연결 부탁드립니다.)


Close #21 