### PR TITLE
fix: discussion 카드 본문 오버플로우 수정 (#35)

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -219,6 +219,24 @@ footer {
     overflow-wrap: break-word;
 }
 
+.discussion-body img,
+.discussion-body video,
+.discussion-body iframe {
+    max-width: 100%;
+    height: auto;
+}
+
+.discussion-body pre {
+    max-width: 100%;
+    overflow-x: auto;
+}
+
+.discussion-body table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+}
+
 .discussion-footer {
     display: flex;
     justify-content: space-between;
@@ -316,5 +334,9 @@ footer {
 
     .discussion-title {
         font-size: 1.1rem;
+    }
+
+    .featured-grid {
+        grid-template-columns: 1fr;
     }
 }

--- a/assets/style.css
+++ b/assets/style.css
@@ -150,6 +150,7 @@ footer {
     padding: 1.5rem;
     background: white;
     transition: box-shadow 0.2s, border-color 0.2s;
+    min-width: 0;
 }
 
 .discussion-card:hover {
@@ -203,6 +204,7 @@ footer {
 .discussion-title a {
     color: #238636;
     text-decoration: none;
+    overflow-wrap: break-word;
 }
 
 .discussion-title a:hover {

--- a/assets/style.css
+++ b/assets/style.css
@@ -220,10 +220,13 @@ footer {
 }
 
 .discussion-body img,
-.discussion-body video,
-.discussion-body iframe {
+.discussion-body video {
     max-width: 100%;
     height: auto;
+}
+
+.discussion-body iframe {
+    max-width: 100%;
 }
 
 .discussion-body pre {

--- a/assets/style.css
+++ b/assets/style.css
@@ -216,6 +216,7 @@ footer {
     line-height: 1.6;
     margin: 0 0 1rem 0;
     font-size: 0.95rem;
+    overflow-wrap: break-word;
 }
 
 .discussion-footer {


### PR DESCRIPTION
## Summary
- `.discussion-card`에 `min-width: 0` 추가 - grid 컨텍스트에서 카드가 컨테이너를 밀어내는 근본 원인 해결
- `.discussion-title a`에 `overflow-wrap: break-word` 추가 - 긴 제목 줄바꿈 처리
- `.discussion-body`에 `overflow-wrap: break-word` 추가 - 긴 URL 및 문자열 강제 줄바꿈
- img/video: max-width 100%, height auto 적용
- iframe: max-width 100%만 적용 (height: auto는 높이 붕괴 유발)
- pre: overflow-x auto로 코드 블록 스크롤 처리
- table: display block + overflow-x auto로 넓은 표 스크롤 처리
- 모바일(768px 이하) featured-grid 단열 강제

## Test plan
- [ ] 긴 URL이 포함된 본문이 카드 박스를 벗어나지 않는지 확인
- [ ] 긴 제목이 카드 박스를 벗어나지 않는지 확인
- [ ] 모바일에서 featured-grid 카드가 단열로 표시되는지 확인
- [ ] hover box-shadow 효과 정상 동작 확인

Closes #35

Generated with Claude Code