### PR TITLE
feat: 새 글 작성 버튼 추가

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -105,6 +105,45 @@ footer {
     padding: 2rem 1rem;
 }
 
+.discussions-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 1.5rem;
+}
+
+.btn-new-post {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.2rem;
+    background-color: #238636;
+    color: #fff;
+    border: 1px solid rgba(27, 31, 36, 0.15);
+    border-radius: 6px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    text-decoration: none;
+    box-shadow: 0 1px 2px rgba(27, 31, 36, 0.08);
+    transition: background-color 0.15s ease, transform 0.1s ease, box-shadow 0.15s ease;
+}
+
+.btn-new-post:hover {
+    background-color: #2ea043;
+    text-decoration: none;
+    box-shadow: 0 3px 8px rgba(35, 134, 54, 0.25);
+}
+
+.btn-new-post:active {
+    background-color: #1f7a30;
+    transform: translateY(1px);
+    box-shadow: inset 0 1px 2px rgba(27, 31, 36, 0.2);
+}
+
+.btn-new-post-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+
 
 .discussions-list {
     display: flex;
@@ -341,5 +380,14 @@ footer {
 
     .featured-grid {
         grid-template-columns: 1fr;
+    }
+
+    .discussions-toolbar {
+        justify-content: stretch;
+    }
+
+    .btn-new-post {
+        width: 100%;
+        justify-content: center;
     }
 }

--- a/index.md
+++ b/index.md
@@ -5,6 +5,15 @@ title: GStreamer 101 - Discussions
 ---
 
 <div class="discussions-container">
+    <div class="discussions-toolbar">
+        <a href="https://github.com/gstreamer101/gstreamer101.github.io/discussions/new/choose"
+           class="btn-new-post"
+           target="_blank"
+           rel="noopener noreferrer">
+            <span class="btn-new-post-icon">✍️</span>
+            <span class="btn-new-post-text">새 글 작성</span>
+        </a>
+    </div>
     <div id="discussions-list" class="discussions-list">
         <div class="loading">로딩 중...</div>
     </div>


### PR DESCRIPTION
## Summary
- 글 목록 상단 우측에 "✍️ 새 글 작성" 버튼 추가
- GitHub Discussions의 `/discussions/new/choose` 페이지로 새 탭 연결
- GitHub 그린 톤(`#238636`) 스타일, hover/active 인터랙션 포함
- 모바일(≤768px)에서는 버튼이 가로 폭 전체로 확장되도록 반응형 처리

## Test plan
- [ ] 데스크탑에서 우측 상단에 버튼이 노출되는지 확인
- [ ] 모바일 뷰에서 버튼이 전체 폭으로 표시되는지 확인
- [ ] 버튼 클릭 시 새 탭에서 Discussions 카테고리 선택 페이지가 열리는지 확인
- [ ] hover/active 상태의 색상 전환 확인