### PR TITLE
fix: 커뮤니티 게시글 최신순 정렬 (closes #37)

### DIFF
--- a/assets/js/discussions.js
+++ b/assets/js/discussions.js
@@ -46,8 +46,8 @@ async function fetchDiscussions() {
 
         // GitHub Discussions API는 정렬 파라미터를 지원하지 않아 클라이언트에서 정렬
         discussions.sort((a, b) => {
-            const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
-            const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
+            const dateA = a.created_at ? (new Date(a.created_at).getTime() || 0) : 0;
+            const dateB = b.created_at ? (new Date(b.created_at).getTime() || 0) : 0;
             return dateB - dateA;
         });
 

--- a/assets/js/discussions.js
+++ b/assets/js/discussions.js
@@ -56,8 +56,7 @@ async function fetchDiscussions() {
             FEATURED_CATEGORIES.includes(d.category?.name)
         );
         const general = discussions.filter(d =>
-            GENERAL_CATEGORIES.includes(d.category?.name) ||
-            (!d.category?.name || !FEATURED_CATEGORIES.includes(d.category?.name))
+            !FEATURED_CATEGORIES.includes(d.category?.name)
         );
 
         displayLayout(featured, general);

--- a/assets/js/discussions.js
+++ b/assets/js/discussions.js
@@ -44,6 +44,13 @@ async function fetchDiscussions() {
             return;
         }
 
+        // GitHub Discussions API는 정렬 파라미터를 지원하지 않아 클라이언트에서 정렬
+        discussions.sort((a, b) => {
+            const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
+            const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
+            return dateB - dateA;
+        });
+
         // 카테고리별로 분류
         const featured = discussions.filter(d =>
             FEATURED_CATEGORIES.includes(d.category?.name)

--- a/assets/js/discussions.js
+++ b/assets/js/discussions.js
@@ -19,7 +19,7 @@ async function fetchDiscussions() {
         }
 
         // 모든 discussions 가져오기 (페이지 단위)
-        const apiUrl = `https://api.github.com/repos/${OWNER}/${REPO}/discussions?per_page=50&sort=created&direction=desc`;
+        const apiUrl = `https://api.github.com/repos/${OWNER}/${REPO}/discussions?per_page=50`;
         const response = await fetch(apiUrl, { headers });
 
         if (!response.ok) {

--- a/assets/style.css
+++ b/assets/style.css
@@ -238,6 +238,7 @@ footer {
     font-size: 1.4rem;
     font-weight: 600;
     color: #333;
+    overflow-wrap: break-word;
 }
 
 .discussion-title a {

--- a/assets/style.css
+++ b/assets/style.css
@@ -190,6 +190,7 @@ footer {
     background: white;
     transition: box-shadow 0.2s, border-color 0.2s;
     min-width: 0;
+    overflow: hidden;
 }
 
 .discussion-card:hover {


### PR DESCRIPTION
## Summary

- GitHub Discussions REST API가 `sort`/`direction` 파라미터를 지원하지 않아 게시글이 오래된 순으로 표시되는 문제를 수정합니다.
- API 응답 수신 후 클라이언트에서 `created_at` 기준 내림차순 정렬을 적용합니다.

## Commits

1. `cleanup`: API URL에서 무효한 `sort=created&direction=desc` 파라미터 제거
2. `fix`: `Array.isArray` 가드 이후 클라이언트 정렬 추가 (closes #37)
3. `fix`: 정렬 비교자에서 잘못된 날짜 문자열로 인한 NaN 방어 처리
4. `fix`: `general` 필터의 이중 렌더링 버그 수정 — featured 카테고리가 두 섹션에 모두 표시되던 문제 해결

## Related

- Closes #37
- 별도 이슈: #39 (`user` 필드 null 시 렌더 크래시 방지)

## Test plan

- [ ] 홈페이지 로드 후 커뮤니티 토론 섹션의 게시글이 최신순(내림차순)으로 표시되는지 확인
- [ ] Announcements/Polls 카테고리 게시글이 상단 "주요 공지" 섹션에만 표시되고 하단 "커뮤니티 토론"에 중복 표시되지 않는지 확인