### PR TITLE
fix: discussion 카드에서 user 필드 null 시 렌더 크래시 방지

### DIFF
--- a/assets/js/discussions.js
+++ b/assets/js/discussions.js
@@ -126,9 +126,9 @@ function createDiscussionCard(discussion) {
 
             <div class="discussion-footer">
                 <div class="author-info">
-                    <img src="${discussion.user.avatar_url}" alt="${discussion.user.login}" class="author-avatar">
+                    <img src="${discussion.user?.avatar_url || ''}" alt="${discussion.user?.login || ''}" class="author-avatar">
                     <div class="author-details">
-                        <span class="author-name">${discussion.user.login}</span>
+                        <span class="author-name">${discussion.user?.login || '알 수 없음'}</span>
                         <span class="post-date">${formatDate(discussion.created_at)}</span>
                     </div>
                 </div>


### PR DESCRIPTION
 ## 문제
  `discussion.user`가 null인 경우(삭제된 계정, 봇 등) `avatar_url`과
  `login`에 직접 접근하면 TypeError가 발생해 페이지 전체 렌더링이 실패합니다.

  ## 해결
  optional chaining과 fallback 값을 적용해 user가 null이어도
  안전하게 렌더링되도록 수정했습니다.

  - `discussion.user?.avatar_url || ''`
  - `discussion.user?.login || ''`
  - `discussion.user?.login || '알 수 없음'`

  Resolves #39