### PR TITLE
fix: 헤더 로고 링크를 홈페이지로 변경

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header">
     <div class="header-inner">
         <div class="site-brand">
-            <a href="https://github.com/gstreamer101" target="_blank" rel="noopener">
+            <a href="{{ site.baseurl }}/">
                 <img src="https://avatars.githubusercontent.com/u/169019837?s=48&v=4" alt="GStreamer 101" class="logo-img">
                 <span class="site-title-text">GStreamer 101</span>
             </a>


### PR DESCRIPTION
Closes #45



## 변경 내용

헤더 로고 링크를 GitHub 프로필에서 홈페이지로 변경



- `_includes/header.html` 로고 링크 수정

- 변경 전: `https://github.com/gstreamer101`

- 변경 후: `{{ site.baseurl }}`

